### PR TITLE
feat(build): overhaul build system with multi-distro deps, install/uninstall targets, and permission handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,67 @@
+# ==========================================
+# 🎮 Trinity Launcher - Makefile Wrapper
+# ==========================================
+
+# Variables
+SCRIPT = ./build.sh
+# Forzamos el uso de bash para evitar errores de sintaxis (sh/dash)
+SHELL_CMD = bash
+
+# Targets (comandos) disponibles
+.PHONY: all build debug deps clean run translations help start uninstall install
+
+# 1. Comando por defecto (solo 'make') -> Compila en modo Release
+all: build
+
+# 2. Compilación Release (Solo genera los binarios en build/)
+build:
+	@$(SHELL_CMD) $(SCRIPT) --release
+
+# 3. Compilación Debug (Con símbolos para gdb/lldb)
+debug:
+	@$(SHELL_CMD) $(SCRIPT) --debug
+
+# 4. Instalar Dependencias (Detecta distro y usa sudo)
+deps:
+	@$(SHELL_CMD) $(SCRIPT) --deps-only
+
+# 5. Limpiar proyecto (Borra carpeta build/ y repara permisos si es necesario)
+clean:
+	@$(SHELL_CMD) $(SCRIPT) --clean
+# 6. Ejecutar el Launcher (Compila Release + Ejecuta en LOCAL)
+# Nota: Ideal para desarrollo, no pide contraseña ni instala en sistema.
+run:
+	@$(SHELL_CMD) $(SCRIPT) --release --run
+
+# 7. Actualizar Traducciones (.ts)
+translations:
+	@$(SHELL_CMD) $(SCRIPT) --update-ts
+
+# 8. Setup completo (Deps + Build + Run)
+# Nota: Ideal para la primera vez que clonas el repo.
+start:
+	@$(SHELL_CMD) $(SCRIPT) --deps --release --run --detached
+
+# 9. Instalar en el Sistema (/usr/local/bin)
+# Nota: Requiere contraseña sudo. Copia los binarios para uso global.
+install:
+	@$(SHELL_CMD) $(SCRIPT) --release --install --detached
+
+# 10. Desinstalar launcher (Elimina de /usr/local/bin , accesos directos y build/)
+uninstall:
+	@$(SHELL_CMD) $(SCRIPT) --clean-only
+	@$(SHELL_CMD) $(SCRIPT) --uninstall
+
+help:
+	@echo "🛠️  Comandos disponibles en Trinity Launcher:"
+	@echo ""
+	@echo "  make          -> Compila el proyecto en modo Release (Igual a 'make build')"
+	@echo "  make start    -> Flujo completo: Deps + Build + Run (Recomendado primera vez)"
+	@echo "  make run      -> Compila y ejecuta la versión LOCAL (Rápido para desarrollo)"
+	@echo "  make install  -> Compila e INSTALA en el sistema (/usr/local/bin) [Pide Sudo]"
+	@echo "  make debug    -> Compila en modo Debug"
+	@echo "  make deps     -> Instala dependencias del sistema"
+	@echo "  make clean    -> Borra la carpeta 'build y recompilar"
+	@echo "  make uninstall -> Elimina Trinity del sistema"
+	@echo "  make translations -> Actualiza archivos de traducción .ts"
+	@echo ""

--- a/README.md
+++ b/README.md
@@ -95,20 +95,45 @@ Incluye dos aplicaciones complementarias:
 ---
 
 ## ⚙️ Compilación e Instalación
-Puedes seguir nuestro manual en:
-https://trinity-la.github.io/
-### Requisitos
+
+Puedes seguir nuestro manual detallado en: [https://trinity-la.github.io/](https://trinity-la.github.io/)
+
+### Requisitos Previos
+
+El sistema instalará automáticamente las dependencias, pero necesitarás tener `make` y `git` instalados inicialmente.
+Depndencias usadas:
 - CMake 3.17+
 - Clang
 - Qt6 (Core, Widgets)
 
-### Proceso
+### 🚀 Método Rápido (Recomendado)
+
 ```sh
-# Dar permisos de ejecución
+# 1. Primera vez (Instala dependencias, compila y ejecuta)
+make start
+
+# 2. Uso diario (Solo compila y ejecuta localmente, para devs)
+make run
+
+# 3. Instalar en el sistema (Opcional, requiere sudo)
+make install
+
+```
+
+### 🛠️ Método Manual (Script)
+
+Si prefieres usar el script directamente para mayor control:
+
+```sh
+# Dar permisos
 chmod +x build.sh
 
-# Compilar e instalar en el sistema
-sudo ./build.sh
+# Instalar dependencias y compilar
+./build.sh --deps --release
+
+# Compilar y ejecutar
+./build.sh --release --run
+
 ```
 
 > 📦 Instala `trinchete` y `trinito` en `/usr/local/bin`, y registra el `.desktop` y el icono en el sistema.
@@ -119,6 +144,15 @@ trinchete
 trinito
 ```
 
+### 📦 Comandos disponibles
+
+| Comando | Descripción |
+| --- | --- |
+| `make start` | Setup completo: Dependencias + Build + Run. |
+| `make run` | Compila y ejecuta la versión local (dev). |
+| `make install` | Instala Trinity en `/usr/local/bin` para todo el sistema. |
+| `make clean` | Limpia la carpeta de compilación y arregla permisos. |
+| `make uninstall` | Elimina Trinity completamente del sistema. |
 ---
 
 ## 🔧 Mcpelauncher Requerido

--- a/build.sh
+++ b/build.sh
@@ -15,8 +15,148 @@ NC='\033[0m' # No Color
 # Variables por defecto
 BUILD_TYPE="Release"
 CLEAN_BUILD=false
+ONLY_CLEAN=false
+ONLY_DEPS=false
 UPDATE_TRANSLATIONS=false
+INSTALL_DEPS=false
+INSTALL_SYSTEM=false
+RUN_APP=false
+DETACHED=false
+UNINSTALL=false
 BUILD_DIR="build"
+
+show_banner() {
+    echo -e "${CYAN}"
+    echo "  _______   _       _ _            "
+    echo " |__   __| (_)     (_) |           "
+    echo "    | |_ __ _ _ __  _| |_ _   _    "
+    echo "    | | '__| | '_ \| | __| | | |   "
+    echo "    | | |  | | | | | | |_| |_| |   "
+    echo "    |_|_|  |_|_| |_|_|\__|\__, |   "
+    echo "                           __/ |   "
+    echo "                          |___/    "
+    echo -e "${NC}"
+    echo -e "${BLUE}=== Trinity Launcher Build System ===${NC}"
+    echo ""
+}
+
+ensure_sudo() {
+    echo -e "${YELLOW}🔐 Se requieren permisos de administrador para esta acción...${NC}"
+    if ! sudo -v; then
+        echo -e "${RED}❌ Error: Permiso denegado.${NC}"
+        exit 1
+    fi
+}
+
+detect_distro() {
+    DISTRO_FAMILY=""
+    OS_ID=""
+
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        OS_ID=$ID
+        case "$ID" in
+            debian|ubuntu|linuxmint|pop|raspbian|kali|neon) DISTRO_FAMILY="debian_based" ;;
+            fedora|rhel|centos|rocky|almalinux) DISTRO_FAMILY="fedora_based" ;;
+            opensuse-leap|opensuse-tumbleweed) DISTRO_FAMILY="opensuse_based" ;;
+            arch|manjaro|endeavouros|garuda) DISTRO_FAMILY="arch_based" ;;
+            *)
+                case "$ID_LIKE" in
+                    *debian*) DISTRO_FAMILY="debian_based" ;;
+                    *fedora*|*rhel*) DISTRO_FAMILY="fedora_based" ;;
+                    *suse*) DISTRO_FAMILY="opensuse_based" ;;
+                    *arch*) DISTRO_FAMILY="arch_based" ;;
+                    *) DISTRO_FAMILY="unknown" ;;
+                esac
+                ;;
+        esac
+    elif type lsb_release >/dev/null 2>&1; then
+        local lsb_id=$(lsb_release -si | tr '[:upper:]' '[:lower:]')
+        case "$lsb_id" in
+            ubuntu|debian|linuxmint|pop|sparky|raspbian) DISTRO_FAMILY="debian_based" ;;
+            fedora|redhat|centos) DISTRO_FAMILY="fedora_based" ;;
+            opensuse|suse) DISTRO_FAMILY="opensuse_based" ;;
+            arch|manjaro) DISTRO_FAMILY="arch_based" ;;
+            *) DISTRO_FAMILY="unknown" ;;
+        esac
+        OS_ID=$lsb_id
+    elif [ -f /etc/arch-release ]; then DISTRO_FAMILY="arch_based"; OS_ID="arch";
+    else DISTRO_FAMILY="unknown"; OS_ID=$(uname -s | tr '[:upper:]' '[:lower:]');
+    fi
+}
+
+install_dependencies() {
+    detect_distro
+    echo -e "${CYAN}🔍 Sistema detectado: $OS_ID ($DISTRO_FAMILY)${NC}"
+    echo -e "${YELLOW}📦 Instalando dependencias... (se requerirá sudo)${NC}"
+
+    ensure_sudo
+
+    case "$DISTRO_FAMILY" in
+        "debian_based")
+            sudo apt-get update
+            sudo apt-get install -y build-essential git curl cmake clang ninja-build \
+                qt6-base-dev qt6-base-dev-tools qt6-declarative-dev qt6-webengine-dev qt6-svg-dev qt6-tools-dev \
+                libcurl4-openssl-dev libssl-dev libasound2-dev libpulse-dev libjack-jackd2-dev libpipewire-0.3-dev \
+                libx11-dev libxi-dev libxext-dev libxfixes-dev libxcursor-dev libxrandr-dev libxss-dev libxtst-dev \
+                libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libvulkan-dev vulkan-validationlayers \
+                libdrm-dev libgbm-dev libudev-dev libevdev-dev libusb-1.0-0-dev libdbus-1-dev bluez \
+                libibus-1.0-dev libxkbcommon-dev libpng-dev libzip-dev libcups2-dev libwayland-dev libunwind-dev libdecor-0-dev
+            ;;
+        "fedora_based")
+            sudo dnf groupinstall -y "Development Tools"
+            sudo dnf install -y git curl cmake clang ninja-build \
+                qt6-qtbase-devel qt6-qtdeclarative-devel qt6-qtwebengine-devel qt6-qtsvg-devel qt6-qttools-devel \
+                libcurl-devel openssl-devel alsa-lib-devel pulseaudio-libs-devel pipewire-devel \
+                libX11-devel libXi-devel libXext-devel libXfixes-devel libXcursor-devel libXrandr-devel libXtst-devel \
+                mesa-libGL-devel vulkan-loader-devel libdrm-devel libgbm-devel systemd-devel libevdev-devel \
+                libusb1-devel dbus-devel bluez-libs-devel libxkbcommon-devel libpng-devel libzip-devel \
+                wayland-devel libunwind-devel libdecor-devel
+            ;;
+        "arch_based")
+            sudo pacman -S --needed base-devel git curl cmake clang ninja \
+                qt6-base qt6-declarative qt6-webengine qt6-svg qt6-tools qt6-translations \
+                libzip libpng libpulse alsa-lib pipewire jack2 sndio \
+                libx11 libxi libxext libxfixes libxcursor libxrandr libxss libxtst \
+                mesa vulkan-devel vulkan-validation-layers libdrm libgbm \
+                libevdev libusb dbus bluez ibus libxkbcommon libunwind libdecor wayland
+            ;;
+        "opensuse_based")
+            sudo zypper install -y -t pattern devel_basis
+            sudo zypper install -y git curl cmake clang ninja libqt6-qtbase-devel \
+                libqt6-qtdeclarative-devel libqt6-qtwebengine-devel libqt6-qtsvg-devel libqt6-qttools-devel \
+                libzip-devel libpng16-devel libopenssl-devel libevdev-devel libdecor-0-devel
+            ;;
+        *)
+            echo -e "${RED}Distro no soportada automáticamente. Revisa el README.${NC}"
+            exit 1
+            ;;
+    esac
+    echo -e "${GREEN}Dependencias instaladas.${NC}"
+}
+
+uninstall_app() {
+    echo -e "${YELLOW}🗑️  Iniciando proceso de desinstalación...${NC}"
+    echo -e "${YELLOW}🔐 Se requieren permisos para eliminar archivos del sistema (/usr/local/bin, etc)${NC}"
+    
+    ensure_sudo
+
+    echo -e "   Eliminando binarios..."
+    sudo rm -f /usr/local/bin/trinchete
+    sudo rm -f /usr/local/bin/trinito
+
+    echo -e "   Eliminando recursos (iconos y accesos directos)..."
+    sudo rm -f /usr/share/icons/com.trench.trinity.launcher.svg
+    sudo rm -f /usr/share/applications/com.trench.trinity.launcher.desktop
+
+    echo -e "${GREEN}✅ Trinity Launcher ha sido eliminado del sistema.${NC}"
+    
+    # No borramos la carpeta de datos (~/.local/share/mcpelauncher) automáticamente
+    # porque ahí están los mundos y partidas guardadas del usuario.
+    echo -e "${BLUE}ℹ️  Nota: Los datos del juego (mundos, skins) se mantienen en:${NC}"
+    echo -e "   ~/.local/share/mcpelauncher/"
+    echo -e "   Si deseas borrarlos también, ejecuta: rm -rf ~/.local/share/mcpelauncher/"
+}
 
 # Función de ayuda
 show_help() {
@@ -25,8 +165,12 @@ show_help() {
     echo "Opciones:"
     echo "  --debug      Compila en modo Debug (con símbolos para depurar)"
     echo "  --release    Compila en modo Release (optimizado, por defecto)"
-    echo "  --clean      Borra la carpeta build/ y compila desde cero"
+    echo "  --clean      Borra build/ y RECOMPILA"
+    echo "  --clean-only Borra build/ y SALE (Sin compilar)"
     echo "  --update-ts  Escanea el código y actualiza los archivos .ts de traducción"
+    echo "  --deps       Instala las dependencias del sistema (detecta distro automáticamente)"
+    echo "  --install    Instala en el sistema (/usr/local/bin)"
+    echo "  --run        Ejecuta Trinchete al terminar"
     echo "  --help       Muestra esta ayuda"
     echo ""
 }
@@ -43,9 +187,24 @@ while [[ "$#" -gt 0 ]]; do
         --clean)
             CLEAN_BUILD=true
             shift ;;
+        --clean-only) CLEAN_BUILD=true; ONLY_CLEAN=true; shift ;;
+        --deps-only) INSTALL_DEPS=true; ONLY_DEPS=true; shift ;;
         --update-ts)
             UPDATE_TRANSLATIONS=true
             shift ;;
+        --deps)
+            INSTALL_DEPS=true
+            shift ;;
+        --run)
+            RUN_APP=true
+            shift ;;
+        --install)
+            INSTALL_SYSTEM=true;
+            shift ;;
+        --uninstall)
+            UNINSTALL=true;
+            shift ;;
+        --detached) DETACHED=true; shift ;;
         --help)
             show_help
             exit 0 ;;
@@ -55,6 +214,48 @@ while [[ "$#" -gt 0 ]]; do
             exit 1 ;;
     esac
 done
+
+show_banner;
+
+if [ "$(id -u)" -eq 0 ]; then
+   echo -e "${RED}❌ ERROR CRÍTICO:${NC} No ejecutes este script con 'sudo'."
+   echo -e "   El script pedirá permisos de administrador automáticamente"
+   echo -e "   solo cuando necesite instalar dependencias y configurar."
+   echo -e "   ${YELLOW}Ejecuta: make start o make run (./build.sh)${NC}"
+   exit 1
+fi
+
+# Esto es vital: Si vas a limpiar o compilar, primero aseguramos que la carpeta sea tuya.
+# pedimos sudo SOLO para arreglar los permisos y devolvértelos.
+# Verificamos si la carpeta existe y si hay archivos de root dentro.
+if [ -d "$BUILD_DIR" ]; then
+    # Buscamos si hay algún archivo propiedad de root (user ID 0)
+    # -print -quit hace que se detenga al encontrar el primero (más rápido)
+    ROOT_FILES=$(find "$BUILD_DIR" -user 0 -print -quit 2>/dev/null)
+
+    if [ ! -w "$BUILD_DIR" ] || [ -n "$ROOT_FILES" ]; then
+        echo -e "${YELLOW}⚠️  Se detectaron archivos creados por root en '$BUILD_DIR'.${NC}"
+        echo -e "${YELLOW}🔓 Solicitando permisos para recuperar la propiedad...${NC}"
+        
+        ensure_sudo
+        
+        if sudo chown -R $USER:$USER "$BUILD_DIR"; then
+            echo -e "${GREEN}✅ Permisos corregidos.${NC}"
+        else
+            echo -e "${RED}❌ Falló la corrección de permisos.${NC}"; exit 1
+        fi
+    fi
+fi
+
+# Ejecución de tareas prioritarias
+if [ "$INSTALL_DEPS" = true ]; then 
+    install_dependencies
+    if [ "$ONLY_DEPS" = true ]; then
+        echo -e "${GREEN}✅ Dependencias listas.${NC}"
+        exit 0
+    fi
+fi
+if [ "$UNINSTALL" = true ]; then uninstall_app; exit 0; fi
 
 # 2. Actualizar Traducciones (Si se solicita)
 if [ "$UPDATE_TRANSLATIONS" = true ]; then
@@ -94,6 +295,10 @@ if [ "$CLEAN_BUILD" = true ]; then
     echo -e "${YELLOW}🧹 Limpiando compilaciones anteriores (--clean)...${NC}"
     rm -rf "$BUILD_DIR"
     rm -f trinchete trinito
+    if [ "$ONLY_CLEAN" = true ]; then
+        echo -e "${GREEN}✅ Limpieza completada. Saliendo.${NC}"
+        exit 0
+    fi
 fi
 
 # 5. Crear directorio build si no existe
@@ -114,23 +319,111 @@ else
     exit 1
 fi
 
-# 8. Mover binarios (Opcional, por comodidad)
-echo -e "${BLUE}📦 Organizando ejecutables...${NC}"
+if [ "$INSTALL_SYSTEM" = true ]; then
+    echo -e "${BLUE}📦 Iniciando instalación en el sistema...${NC}"
 
-# Verificar si los binarios existen antes de moverlos
-if [ -f "$BUILD_DIR/app/trinchete" ]; then
-    sudo cp -rf "$BUILD_DIR/app/trinchete" /usr/local/bin
-    echo -e "   -> trinchete listo"
+    ensure_sudo
+
+    # Instalar Trinchete (Obligatorio)
+    if [ -f "$BUILD_DIR/app/trinchete" ]; then
+        sudo cp -rf "$BUILD_DIR/app/trinchete" /usr/local/bin
+        echo -e "   -> trinchete instalado en /usr/local/bin"
+    else
+        echo -e "${RED}❌ Error: No se encontró el binario 'trinchete'. Compila primero.${NC}"
+        exit 1
+    fi
+
+    # Instalar Trinito (Opcional/Complementario)
+    if [ -f "$BUILD_DIR/app/trinito" ]; then
+        sudo cp "$BUILD_DIR/app/trinito" /usr/local/bin
+        echo -e "   -> trinito instalado en /usr/local/bin"
+    fi
+
+    # Instalar Iconos (Verificando existencia)
+    if [ -f "resources/branding/com.trench.trinity.launcher.svg" ]; then
+        sudo cp -rf resources/branding/com.trench.trinity.launcher.svg /usr/share/icons/
+    else
+        echo -e "${YELLOW}⚠️  No se encontró el icono (.svg), se omitió su copia.${NC}"
+    fi
+
+    # Instalar Acceso Directo (Verificando existencia)
+    if [ -f "resources/shortcuts/com.trench.trinity.launcher.desktop" ]; then
+        sudo cp -rf resources/shortcuts/com.trench.trinity.launcher.desktop /usr/share/applications/
+    else
+        echo -e "${YELLOW}⚠️  No se encontró el acceso directo (.desktop), se omitió su copia.${NC}"
+    fi
+
+    echo -e "${GREEN}✅ Instalación completada.${NC}"
+
+    if [ "$RUN_APP" = false ]; then
+        echo ""
+        echo -e "${CYAN}❓ ¿Deseas iniciar Trinity Launcher ahora? (s/n)${NC}"
+        read -p "" -n 1 -r REPLY
+        echo ""
+        if [[ $REPLY =~ ^[SsYy]$ ]]; then
+            echo -e "${GREEN}🚀 Lanzando en segundo plano...${NC}"
+            RUN_APP=true
+            DETACHED=true
+        fi
+    fi
 fi
 
-if [ -f "$BUILD_DIR/app/trinito" ]; then
-    sudo cp "$BUILD_DIR/app/trinito" /usr/local/bin
-    echo -e "   -> trinito listo"
+if [ "$RUN_APP" = true ]; then
+    
+    APP_PATH=""
+    # Selección del binario
+    if [ -f "$BUILD_DIR/app/trinchete" ]; then
+        APP_PATH="$BUILD_DIR/app/trinchete"
+    elif command -v trinchete &> /dev/null; then
+        APP_PATH=$(command -v trinchete)
+    else
+        echo -e "${RED}❌ No se pudo encontrar el ejecutable.${NC}"
+        exit 1
+    fi
+
+    # --- CASO A: MODO USUARIO (Sin logs, libera terminal) ---
+    if [ "$DETACHED" = true ]; then
+        echo -e "${CYAN}🎮 Lanzando Trinchete...${NC}"
+        "$APP_PATH" & > /dev/null 2>&1
+        echo -e "${GREEN}✅ Aplicación iniciada en segundo plano.${NC}"
+    
+    # --- CASO B: MODO DEV (Logs, Ctrl+C, Espera) ---
+    else
+        echo -e "${CYAN}🎮 Lanzando Trinchete (Modo Desarrollo)...${NC}"
+        echo -e "${YELLOW}⚡ Ejecutando: $APP_PATH${NC}"
+        echo -e "${YELLOW}ℹ️  Logs en vivo. Presiona Ctrl+C para detener.${NC}"
+        echo ""
+
+        cleanup() {
+            echo ""
+            echo -e "${RED}🛑 Deteniendo aplicación...${NC}"
+            if [ -n "$APP_PID" ]; then kill "$APP_PID" 2>/dev/null; fi
+            exit 0
+        }
+        trap cleanup SIGINT
+
+        "$APP_PATH" &
+        APP_PID=$!
+        wait "$APP_PID"
+        
+        EXIT_CODE=$?
+        echo ""
+        if [ $EXIT_CODE -eq 0 ]; then
+            echo -e "${GREEN}✅ Aplicación cerrada correctamente.${NC}"
+        else
+            echo -e "${RED}⚠️  Cierre con código: $EXIT_CODE${NC}"
+        fi
+    fi
 fi
 
-# Copiamos los iconos del launcher
-sudo cp -rf resources/branding/com.trench.trinity.launcher.svg /usr/share/icons/
-sudo cp -rf resources/shortcuts/com.trench.trinity.launcher.desktop /usr/share/applications/
+echo ""
+if [ "$DETACHED" = true ]; then
+    # Si fue detached, ya terminamos
+    echo -e "${GREEN}🎉 ¡Todo listo!${NC}"
+else
+    # Si fue modo dev, acabamos de cerrar la app
+    echo -e "${GREEN}🎉 Sesión finalizada.${NC}"
+fi
 
 echo ""
 echo -e "${GREEN}🎉 ¡Todo listo!${NC}"


### PR DESCRIPTION
##  Summary
This PR overhauls the `build.sh` script and `Makefile` to provide a complete development and installation lifecycle manager.

##  Key Changes
- **Multi-distro Support:** Auto-detects and installs dependencies for Debian, Fedora, Arch, and OpenSUSE.
- **System Integration:** Added `--install` and `--uninstall` flags to manage binaries in `/usr/local/bin` and desktop entries.
- **Smart Permissions:** Implemented auto-repair logic to fix ownership issues (root vs user) in the `build/` directory, fixing `make clean` errors.
- **Developer vs User Modes:**
  - `make run`: Interactive mode with logs (for devs).
  - `make start`: Detached mode (for users).
- **Optimization:** Added `--deps-only` and `--clean-only` to avoid redundant compilation cycles.

##  How to Test
1. Run `make start` on a fresh machine (should ask for deps and launch).
2. Run `make install` (should copy files to system).
3. Run `make uninstall` (should remove files and clean build dir).